### PR TITLE
fix: Display task instruction/prompt correctly in frontend status widget

### DIFF
--- a/src/frontend.py
+++ b/src/frontend.py
@@ -468,22 +468,32 @@ class CometRunnerApp:
         """Render a single task item in the status widget."""
         # Get task info
         task_type = task.get('task_type', 'unknown')
-        
-        # For AI tasks, show prompt (truncated)
-        if task_type == "ai":
-            prompt = task.get('instruction', 'Unknown')
+
+        # For AI tasks and ConfigurableTask (custom), show prompt/instruction
+        if task_type == "ai" or task_type == "custom":
+            # Try to get instruction field
+            prompt = task.get('instruction', None)
+
+            # If no instruction, try to get from inputs (for ConfigurableTask)
+            if not prompt:
+                inputs = task.get('inputs', {})
+                prompt = inputs.get('instruction', 'Unknown')
+
             # Truncate long prompts
             if len(prompt) > 30:
                 display_text = prompt[:27] + "..."
             else:
                 display_text = prompt
-        else:
+        elif task_type == "url":
             # For URL tasks, show URL
             url = task.get('url', 'Unknown')
             if len(url) > 30:
                 display_text = url[:27] + "..."
             else:
                 display_text = url
+        else:
+            # Unknown task type - show generic info
+            display_text = f"Task ({task_type})"
         
         # Determine status and colors
         if is_current:

--- a/src/tasks/configurable_task.py
+++ b/src/tasks/configurable_task.py
@@ -140,3 +140,18 @@ class ConfigurableTask(BaseTask):
             descriptions[step_num] = (current, next_desc)
             
         return descriptions
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize task to dictionary.
+
+        Adds workflow-specific fields including inputs.
+        """
+        data = super().to_dict()
+        data['workflow_name'] = self.workflow_config.name
+        data['inputs'] = self.inputs
+        # Add instruction field for backward compatibility with frontend
+        # (frontend expects 'instruction' for AI tasks)
+        if 'instruction' in self.inputs:
+            data['instruction'] = self.inputs['instruction']
+        return data


### PR DESCRIPTION
## Summary
- Fixed bug where AI task prompts displayed as "Unknown" in the frontend status widget
- ConfigurableTask now properly serializes instruction field in to_dict() method
- Frontend now correctly handles "custom" task type (ConfigurableTask)

## Problem
When submitting AI prompts via the frontend, the right-side status widget would show "Unknown" instead of the actual prompt text. This was because:
1. ConfigurableTask (used for AI assistant workflows) did not override to_dict() to include the instruction field
2. Frontend only checked for task_type "ai" and "url", but ConfigurableTask uses "custom"

## Solution
**Backend (src/tasks/configurable_task.py)**:
- Added to_dict() method that includes:
  - `workflow_name` field
  - `inputs` dictionary
  - `instruction` field (for backward compatibility with frontend)

**Frontend (src/frontend.py)**:
- Updated `_render_task_item()` to handle "custom" task_type
- Added fallback to `inputs.instruction` if direct `instruction` field not present
- Better task type handling with explicit checks

## Testing
- ✅ Backend build completed successfully (dist/backend.exe)
- Code follows existing patterns and is backward compatible

## Screenshots
N/A (functional fix without UI changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)