### PR TITLE
fix: Correct branch name from 'min' to 'main' in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Build & Release
 
 on:
   push:
-    branches: [ min ]
+    branches: [ main ]
   workflow_dispatch:  # Allow manual triggering
 
 jobs:


### PR DESCRIPTION
## Summary

Fixes a typo in the release workflow configuration where the trigger branch was incorrectly set to `min` instead of `main`.

## Problem

The `release.yml` workflow was configured to trigger on pushes to the `min` branch, which doesn't exist in the repository. This prevented the workflow from ever running automatically, explaining why there were no workflow runs visible in the Actions tab.

## Changes

- Updated `.github/workflows/release.yml` line 5: changed `branches: [ min ]` to `branches: [ main ]`

## Impact

After this fix is merged:
- The Build & Release workflow will automatically trigger when code is pushed to the `main` branch
- Manual triggers via `workflow_dispatch` will continue to work as before
- The workflow will create GitHub releases with version tags based on `version.txt`

## Test Plan

- [ ] Merge this PR to `main`
- [ ] Verify the workflow automatically runs after merge
- [ ] Check that a new release is created at https://github.com/lihaoz-barry/comet-taskrunner/releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)